### PR TITLE
Adding write support with better documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /target
 /Cargo.lock
-/data/test/*
+/data
 *.csv

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ tokio-stream = "0.1.14"
 tokio = { version = "1.33.0", features = ["fs", "io-util", "io-std"] }
 aws-sdk-s3 = "0.35.0"
 aws-config = "0.57.1"
+aws-smithy-runtime-api = "0.57.1"
 
 [dev-dependencies]
 tokio = { version = "1.33.0", features = ["full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,20 @@ name = "s3-filesystem"
 version = "0.0.1"
 edition = "2021"
 
+description = "A crate to sync files on AWS S3 to your local machine."
+license = "MIT OR Apache-2.0"
+authors = [
+    "Andrew Bowell <andrewbowell@mail.com>",
+    "Nathaniel Curnick <nathaniel.curnick@gmail.com>",
+]
+keywords = ["S3", "filesystem", "AWS"]
+categories = ["filesystem"]
+repository = "https://github.com/AnBowell/s3-filesystem"
+homepage = "https://github.com/AnBowell/s3-filesystem"
+documentation = "https://docs.rs/s3-filesystem/latest/s3-filesystem/"
+readme = "README.md"
+
+
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "s3-filesystem"
-version = "0.1.0"
+version = "0.0.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 tokio-stream = "0.1.14"
 tokio = { version = "1.33.0", features = ["fs", "io-util", "io-std"] }
-aws-sdk-s3 = "0.33.0"
-aws-config = "0.56.1"
+aws-sdk-s3 = "0.35.0"
+aws-config = "0.57.1"
 
 [dev-dependencies]
 tokio = { version = "1.33.0", features = ["full"] }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,20 @@
-# S3-Filesystem 
-A way to asynchronously interact with S3 files as if they were local on your disk. 
+# s3-filesystem 
+This crate is a simple wrapper for file interactions with S3. It enables you to open a file, write a file, and perform a walk through the objects in an S3 bucket. Both reading and writing will create a copy on your machine to make S3 feel as much like your local file system as possible. 
+
+
+This crate utilises the offical AWS SDK for S3 operations and uses Tokio for local IO.
+
+# Usage
+First create an OpenOptions struct containing the bucket you wish to connect to and where you wish files to be cached to. 
+
+There are then three functions available 
+- **open_s3**: Downloads the file and opens it and returns a Tokio File for data to be read from as standard.
+- **write_s3**: Writes the file to disk and to S3, returning the Tokio File.
+- **walkdir**: Walks through the objects in the S3 bucket, with an optional path to walk through a subset of objects.
+
 
 ## Open a file
+
 ```rust no_run
 use s3_filesystem::OpenOptions;
 use tokio::io::AsyncReadExt;
@@ -49,8 +62,6 @@ async fn main() {
 }
 ```
 ## Walkdir and download 
-
-## Walkdir and download
 
 ```rust no_run
 use s3_filesystem::OpenOptions;

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,43 +1,48 @@
 use aws_sdk_s3::{error::SdkError, primitives::ByteStreamError};
-use std::{io, fmt::Debug};
-
+use std::{fmt::Debug, io};
 
 #[derive(Debug)]
-pub enum S3FilesystemError<E,R>{
+/// Container for errors that can occur due to AWS or local I/O.
+pub enum S3FilesystemError<E, R> {
+    /// Occurs when a request to S3 is unsuccessful - for instance when a non-existent object is requested.
     S3(SdkError<E, R>),
+    /// Occurs when a reading or writing to/from a ByteStream (used for S3 downloads/uploads).
     ByteStream(ByteStreamError),
-    IO(io::Error)
+    /// Occurs when there are issues with the local file system - for instance, creating a file with an invalid character in the filename.
+    Io(io::Error),
 }
 
-impl <E,R>From<io::Error> for S3FilesystemError<E,R>{
+impl<E, R> From<io::Error> for S3FilesystemError<E, R> {
     fn from(err: io::Error) -> Self {
-        Self::IO(err)
+        Self::Io(err)
     }
 }
 
-impl <E,R>From<SdkError<E,R>> for S3FilesystemError<E,R>{
-    fn from(err: SdkError<E,R>) -> Self {
+impl<E, R> From<SdkError<E, R>> for S3FilesystemError<E, R> {
+    fn from(err: SdkError<E, R>) -> Self {
         Self::S3(err)
     }
 }
 
-impl <E,R>From<ByteStreamError> for S3FilesystemError<E,R>{
+impl<E, R> From<ByteStreamError> for S3FilesystemError<E, R> {
     fn from(err: ByteStreamError) -> Self {
         Self::ByteStream(err)
     }
 }
-impl <E,R>std::fmt::Display for S3FilesystemError<E,R> {
+impl<E, R> std::fmt::Display for S3FilesystemError<E, R> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
-        match self{
-            S3FilesystemError::S3(s3_err) => write!(f, "S3 Error {}", s3_err.to_string()),
-            S3FilesystemError::IO(io_err) => write!(f, "IO Error: {}", io_err.to_string()),
-            S3FilesystemError::ByteStream(bytestream_error) => write!(f, "Bytestream error: {}", bytestream_error.to_string())
+        match self {
+            S3FilesystemError::S3(s3_err) => write!(f, "S3 Error: {}", s3_err),
+            S3FilesystemError::Io(io_err) => write!(f, "IO Error: {}", io_err),
+            S3FilesystemError::ByteStream(bytestream_error) => {
+                write!(f, "ByteStream error: {}", bytestream_error)
+            }
         }
- 
     }
 }
-impl <E,R>std::error::Error for S3FilesystemError<E,R> where
-E: std::error::Error + 'static,
-R: Debug
+impl<E, R> std::error::Error for S3FilesystemError<E, R>
+where
+    E: std::error::Error + 'static,
+    R: Debug,
 {
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,43 @@
+use aws_sdk_s3::{error::SdkError, primitives::ByteStreamError};
+use std::{io, fmt::Debug};
+
+
+#[derive(Debug)]
+pub enum S3FilesystemError<E,R>{
+    S3(SdkError<E, R>),
+    ByteStream(ByteStreamError),
+    IO(io::Error)
+}
+
+impl <E,R>From<io::Error> for S3FilesystemError<E,R>{
+    fn from(err: io::Error) -> Self {
+        Self::IO(err)
+    }
+}
+
+impl <E,R>From<SdkError<E,R>> for S3FilesystemError<E,R>{
+    fn from(err: SdkError<E,R>) -> Self {
+        Self::S3(err)
+    }
+}
+
+impl <E,R>From<ByteStreamError> for S3FilesystemError<E,R>{
+    fn from(err: ByteStreamError) -> Self {
+        Self::ByteStream(err)
+    }
+}
+impl <E,R>std::fmt::Display for S3FilesystemError<E,R> {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        match self{
+            S3FilesystemError::S3(s3_err) => write!(f, "S3 Error {}", s3_err.to_string()),
+            S3FilesystemError::IO(io_err) => write!(f, "IO Error: {}", io_err.to_string()),
+            S3FilesystemError::ByteStream(bytestream_error) => write!(f, "Bytestream error: {}", bytestream_error.to_string())
+        }
+ 
+    }
+}
+impl <E,R>std::error::Error for S3FilesystemError<E,R> where
+E: std::error::Error + 'static,
+R: Debug
+{
+}

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,6 +1,10 @@
-
-
-use aws_sdk_s3::{Client, operation::{get_object::GetObjectError, put_object::PutObjectError, list_objects_v2::ListObjectsV2Error}, primitives::ByteStream};
+use aws_sdk_s3::{
+    operation::{
+        get_object::GetObjectError, list_objects_v2::ListObjectsV2Error, put_object::PutObjectError,
+    },
+    primitives::ByteStream,
+    Client,
+};
 use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use std::{
     io,
@@ -15,7 +19,7 @@ use crate::error::S3FilesystemError;
 
 pub const DEFAULT_DATA_STORE: &'static str = "target/temp";
 
-/// Holds configuration data for opening a file from S3.
+/// Holds configuration data for syncing S3 objects.
 ///
 /// Bucket will specify the bucket which is mounted at mount_path. It will
 /// download the file from the bucket to the path maintaining the same folder
@@ -32,17 +36,30 @@ pub struct OpenOptions {
 impl OpenOptions {
     /// Create a new OpenOptions struct.
     ///
-    /// This function should be used to create a new option configuration for
-    /// using an S3 bucket as if it were local to disk. A bucket is required and
-    /// if data is needed from another bucket, a new OpenOptions should be created.
+    /// This function should be used to create a new option configuration for your S3 bucket and
+    /// filesystem. If data is needed from another bucket, a new OpenOptions should be created.
     ///
-    /// Client is an optional argument - if it exists that will be the client used,
+    /// Client is an optional argument - if it exists that will be the client used
     /// and if it doesn't, this function will automatically create an S3 client
     /// from your environment (the AWS CLI).
     ///
     /// If non default mount paths are wanted, the function [OpenOptions::mount_path] can be
     /// used, and if you wish to re-download data each time, [OpenOptions::force_download] can
     /// be used.
+    ///
+    /// # Examples
+    ///
+    ///```no_run
+    /// use s3_filesystem::OpenOptions;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///  let open_options = OpenOptions::new(bucket, None)
+    ///     .await
+    ///     .mount_path("data/test/")
+    ///     .force_download(true);
+    /// }
+    /// ```
     pub async fn new(bucket: String, client: Option<Client>) -> Self {
         let s3_client = match client {
             Some(x) => x,
@@ -83,30 +100,52 @@ impl OpenOptions {
 }
 
 impl OpenOptions {
-    /// Open a file from S3 as if it were local.
+    /// Open a file from S3.
     ///
-    /// This function will find the S3 file, download it and return a [tokio::fs::File]
-    /// which can be used as it normally would be. I've opted for read/write to disk so that
-    /// large files can be downloaded and read in a chunked way and do not have to be read in their entirety
-    /// into memory.
+    /// This function will find the S3 file, download it and return a [tokio::fs::File] ready to be read. Doing it this way
+    /// enables large files to be downloaded in chunks as well as local caching..
     ///
     /// Files will be placed in the `mount_path` and all folder structure is retained. Folders will be created
     /// if they do not exist already.
     ///
-    pub async fn open_s3<P>(&self, path: P) -> Result<File, S3FilesystemError<GetObjectError,HttpResponse>>
+    /// # Arguments
+    /// * `path`: The path, including filename, of the file to be downloaded and opened.
+    ///```no_run
+    /// use s3_filesystem::OpenOptions;
+    /// use tokio::io::AsyncReadExt;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///  let open_options = OpenOptions::new(bucket, None)
+    ///     .await
+    ///     .mount_path("data/test/")
+    ///     .force_download(true);
+    ///
+    /// let mut file = open_options
+    ///     .open_s3("redasa1-Q1-20/manifest.txt")
+    ///     .await
+    ///     .unwrap();
+    ///
+    ///  let mut string = String::new();
+    ///
+    ///  file.read_to_string(&mut string).await.unwrap();
+    ///
+    ///  println!("String: {}", string);
+    /// }
+    /// ```
+    pub async fn open_s3<P>(
+        &self,
+        path: P,
+    ) -> Result<File, S3FilesystemError<GetObjectError, HttpResponse>>
     where
         P: AsRef<Path>,
-       
     {
         let full_data_path = self.mount_path.join(&self.bucket).join(&path);
 
         let s3_data_path = match path.as_ref().to_str() {
             Some(path) => path.replace("\\", "/"),
             None => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "Invalid File Path",
-                ).into())
+                return Err(io::Error::new(io::ErrorKind::InvalidInput, "Invalid File Path").into())
             }
         };
 
@@ -137,7 +176,7 @@ impl OpenOptions {
             Ok(x) => x,
             Err(e) => {
                 tokio::fs::remove_file(&full_data_path).await?;
-                return Err(e.into()) // TODO:  Error handling. Maybe a custom error?
+                return Err(e.into());
             }
         };
 
@@ -152,10 +191,41 @@ impl OpenOptions {
 
     /// Write a file to S3
     ///
-    /// Enter the path, relative to the bucket, and this function will create a
-    /// file in S3. It will return the file that has been written to.
+    /// Enter a path relative to the bucket and this function will create a file in S3 and on your local system under
+    /// the mount path chosen in [OpenOptions]. This will overwrite any files that exist with the same name and will
+    /// return the file that has been written to.
     ///
-    pub async fn write_s3<P>(&self, path: P, buf: &[u8]) ->Result<File, S3FilesystemError<PutObjectError, HttpResponse>>
+    /// # Arguments
+    /// * `path`: The path, including the filename, where you wish to store the data.
+    /// * `buf`: The data you wish to store.
+    ///
+    /// # Examples
+    /// ```no_run
+    /// use s3_filesystem::OpenOptions;
+    /// use tokio::fs;
+    ///
+    /// const BUCKET: &'static str = "test-bucket";
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let bucket = BUCKET.to_string();
+    ///
+    ///     let open_options = OpenOptions::new(bucket, None)
+    ///         .await
+    ///         .mount_path("data/test/")
+    ///         .force_download(true);
+    ///
+    ///     let data = fs::read("data/manifest.txt").await.unwrap();
+    ///
+    ///     open_options.write_s3("manifest.txt", &data).await.unwrap();
+    ///
+    ///     println!("Data uploaded successfully");
+    /// }
+    pub async fn write_s3<P>(
+        &self,
+        path: P,
+        buf: &[u8],
+    ) -> Result<File, S3FilesystemError<PutObjectError, HttpResponse>>
     where
         P: AsRef<Path>,
     {
@@ -167,15 +237,12 @@ impl OpenOptions {
         let s3_data_path = match path.as_ref().to_str() {
             Some(path) => path.replace("\\", "/"),
             None => {
-                return Err(io::Error::new(
-                    io::ErrorKind::InvalidInput,
-                    "Invalid File Path",
-                ).into())
+                return Err(io::Error::new(io::ErrorKind::InvalidInput, "Invalid File Path").into())
             }
         };
 
         let mut file = tokio::fs::OpenOptions::new()
-            .read(true) 
+            .read(true)
             .write(true)
             .create(true)
             .open(&full_data_path)
@@ -183,7 +250,7 @@ impl OpenOptions {
 
         file.write_all(buf).await?;
 
-        let byte_stream = ByteStream::from_path(full_data_path).await?;
+        let byte_stream = ByteStream::from_path(&full_data_path).await?;
 
         let put_object_builder = self.s3_client.put_object().bucket(&self.bucket);
         return match put_object_builder
@@ -192,19 +259,47 @@ impl OpenOptions {
             .send()
             .await
         {
-            Ok(_) => Ok(file),//Todo - remove the file!
+            Ok(_) => Ok(file),
             Err(e) => {
-                return Err(e.into()); 
+                tokio::fs::remove_file(&full_data_path).await?;
+                return Err(e.into());
             }
         };
     }
 
-    /// Return a vector of Directories/Files in a WalkDir order.
+    /// Return a list of S3 objects within the bucket
     ///
-    /// This function returns the files and folders in the bucket defined in [OpenOptions].
+    /// This function returns the files and folders (S3 objects) in the bucket defined in [OpenOptions]. A sub path
+    /// can be specified to return a subset of the items - for the entire bucket provide an empty string: "".
     ///
-    /// It returns their path, size, and whether or not they're a directory.
-    pub async fn walkdir<P>(&self, path: P) -> Result<Vec<DirEntry>, S3FilesystemError<ListObjectsV2Error, HttpResponse>>
+    /// It returns their path, size, and whether or not it's a directory, but be wary - directories do not exist in S3.
+    /// This function will return any directories that have been created as a dummy object ending in "/" within S3. It is not
+    /// guaranteed to find all directories. This may change in upcoming versions.
+    ///
+    /// # Arguments
+    /// * `path`: A path to search within the S3 bucket. If you want the entire bucket, just specify an empty string: "".
+    ///
+    /// # Examples
+    /// ```rust no_run
+    /// use s3_filesystem::OpenOptions;
+    ///
+    /// #[tokio::main]
+    /// async fn main() {
+    ///     let bucket = "my_aws_s3_bucket".to_string();
+    ///
+    ///     let open_options = OpenOptions::new(bucket, None).await;
+    ///
+    ///     let data = open_options.walkdir("").await.unwrap();
+    ///
+    ///     for dat in data {
+    ///         println!("Data: {:?}", dat);
+    ///     }
+    /// }
+    /// ```
+    pub async fn walkdir<P>(
+        &self,
+        path: P,
+    ) -> Result<Vec<DirEntry>, S3FilesystemError<ListObjectsV2Error, HttpResponse>>
     where
         P: AsRef<Path>,
     {
@@ -216,7 +311,8 @@ impl OpenOptions {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidInput,
                     "Invalid filepath for S3. Please ensure it's UTF-8 only.",
-                ).into())
+                )
+                .into())
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![deny(missing_docs, unused_imports)]
 
 mod fs;
+mod error;
 
 pub use crate::fs::DirEntry;
 pub use crate::fs::OpenOptions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,9 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_docs, unused_imports)]
 
-mod fs;
 mod error;
+mod fs;
 
+pub use crate::error::S3FilesystemError;
 pub use crate::fs::DirEntry;
 pub use crate::fs::OpenOptions;

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1,7 +1,7 @@
 /// The read tests in this file use REDASA COVID-19 Open Data stored on S3 as part of the AWS open data sponsorship program.
 ///
-/// It is stored on eu-west2 - if your AWS client is not connected to eu-west2 it will fail.
-/// TODO -  use a specified region.
+/// IMPORTANT: for the tests to work you will need to be signed into AWS via the CLI. If your AWS client is not connected to eu-west2 it will fail,
+/// as this is where the free data is stored.
 use s3_filesystem::OpenOptions;
 use tokio::io::AsyncReadExt;
 
@@ -24,7 +24,6 @@ async fn test_open_file() {
 
     let mut string = String::new();
 
-    // read the whole file
     file.read_to_string(&mut string).await.unwrap();
 
     println!("String: {}", string);

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1,9 +1,16 @@
+/// The read tests in this file use REDASA COVID-19 Open Data stored on S3 as part of the AWS open data sponsorship program.
+///
+/// It is stored on eu-west2 - if your AWS client is not connected to eu-west2 it will fail.
+/// TODO -  use a specified region.
 use s3_filesystem::OpenOptions;
 use tokio::io::AsyncReadExt;
 
+// eu-west2 public data.
+const BUCKET: &'static str = "pansurg-curation-workflo-kendraqueryresults50d0eb-open-data";
+
 #[tokio::test]
 async fn test_open_file() {
-    let bucket = "my-test-bucket".to_string();
+    let bucket = BUCKET.to_string();
 
     let open_options = OpenOptions::new(bucket, None)
         .await
@@ -11,7 +18,7 @@ async fn test_open_file() {
         .force_download(true);
 
     let mut file = open_options
-        .open_s3("my_test_folder/my_test_file.csv")
+        .open_s3("redasa1-Q1-20/manifest.txt")
         .await
         .unwrap();
 
@@ -25,11 +32,11 @@ async fn test_open_file() {
 
 #[tokio::test]
 async fn test_walk_dir() {
-    let bucket = "my-test-bucket".to_string();
+    let bucket = BUCKET.to_string();
 
     let open_options = OpenOptions::new(bucket, None).await;
 
-    let data = open_options.walkdir("android").await.unwrap();
+    let data = open_options.walkdir("redasa1-Q1-20").await.unwrap();
     for dat in data {
         println!("Data: {:?}", dat);
     }
@@ -37,14 +44,14 @@ async fn test_walk_dir() {
 
 #[tokio::test]
 async fn combine_walkdir_and_download() {
-    let bucket = "my-test-bucket".to_string();
+    let bucket = BUCKET.to_string();
 
     let open_options = OpenOptions::new(bucket, None)
         .await
         .mount_path("data/test/")
         .force_download(false);
 
-    let data = open_options.walkdir("my_test_folder").await.unwrap();
+    let data = open_options.walkdir("redasa1-Q1-20").await.unwrap();
 
     for entry in data {
         if entry.folder {
@@ -52,7 +59,6 @@ async fn combine_walkdir_and_download() {
         }
 
         let _s3_stuff = open_options.open_s3(&entry.path).await.unwrap();
-
         println!("entry: {:?} downloaded", entry.path);
     }
 }

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -1,0 +1,22 @@
+use s3_filesystem::OpenOptions;
+
+use tokio::fs;
+
+// eu-west2 public data.
+const BUCKET: &'static str = "test-bucket";
+
+#[tokio::test]
+async fn test_write_file() {
+    let bucket = BUCKET.to_string();
+
+    let open_options = OpenOptions::new(bucket, None)
+        .await
+        .mount_path("data/test/")
+        .force_download(true);
+
+    let data = fs::read("data/manifest.txt").await.unwrap();
+
+    open_options.write_s3("manifest.txt", &data).await.unwrap();
+
+    println!("Data uploaded successfully");
+}


### PR DESCRIPTION
This request adds write support to the crate. With this, I've added better error handling with a central enum handling all types of errors in the crate. 

It also adds better documentation with examples and attempts to make the tests more accessible - it's easy to do this for reading open datasets but I can't do the same for writing. 

Resolves:
- #3 
- #4 
- #5 
- #6 

